### PR TITLE
Adding type as an option

### DIFF
--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -4,6 +4,53 @@ use crate::error::BiosParseError;
 use smbioslib::*;
 use structopt::StructOpt;
 
+/*
+       Keyword     Types
+       ------------------------------
+       bios        0, 13
+       system      1, 12, 15, 23, 32
+       baseboard   2, 10, 41
+       chassis     3
+       processor   4
+       memory      5, 6, 16, 17
+       cache       7
+       connector   8
+       slot        9
+*/
+
+#[derive(Debug)]
+pub enum BiosType {
+    Bios,
+    System,
+    Baseboard,
+    Chassis,
+    Processor,
+    Memory,
+    Cache,
+    Connector,
+    Slot,
+    Numeric(u8),
+}
+
+impl FromStr for BiosType {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bios" => Ok(BiosType::Bios),
+            "system" => Ok(BiosType::System),
+            "baseboard" => Ok(BiosType::Baseboard),
+            "chassis" => Ok(BiosType::Chassis),
+            "processor" => Ok(BiosType::Processor),
+            "memory" => Ok(BiosType::Memory),
+            "cache" => Ok(BiosType::Cache),
+            "connector" => Ok(BiosType::Connector),
+            "slot" => Ok(BiosType::Slot),
+            _ => Ok(BiosType::Numeric(u8::from_str(s)?)),
+        }
+    }
+}
+
 #[derive(Debug, StructOpt)]
 pub enum Keyword {
     BiosVendor,
@@ -70,140 +117,144 @@ impl FromStr for Keyword {
     }
 }
 
-pub fn opt_string_keyword(keyword: Keyword, data: &SMBiosData) -> Result<String, BiosParseError> {
-    match keyword {
-        Keyword::BiosVendor => data
-            .find_map(|bios_info: SMBiosInformation<'_>| bios_info.vendor())
-            .ok_or(BiosParseError::BiosVendorNotFound),
-        Keyword::BiosVersion => data
-            .find_map(|bios_info: SMBiosInformation<'_>| bios_info.version())
-            .ok_or(BiosParseError::BiosVersionNotFound),
-        Keyword::BiosReleaseDate => data
-            .find_map(|bios_info: SMBiosInformation<'_>| bios_info.release_date())
-            .ok_or(BiosParseError::BiosReleaseDateNotFound),
-        Keyword::BiosRevision => data
-            .find_map(|bios_info: SMBiosInformation<'_>| {
-                match (
-                    bios_info.system_bios_major_release(),
-                    bios_info.system_bios_minor_release(),
-                ) {
-                    (Some(major), Some(minor)) => Some(format!("{}.{}", major, minor)),
-                    _ => None,
-                }
-            })
-            .ok_or(BiosParseError::BiosRevisionNotFound),
-        Keyword::FirmewareRevision => data
-            .find_map(|bios_info: SMBiosInformation<'_>| {
-                match (
-                    bios_info.e_c_firmware_major_release(),
-                    bios_info.e_c_firmware_minor_release(),
-                ) {
-                    (Some(major), Some(minor)) => Some(format!("{}.{}", major, minor)),
-                    _ => None,
-                }
-            })
-            .ok_or(BiosParseError::FirmewareRevisionNotFound),
-        Keyword::SystemManufacturer => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.manufacturer())
-            .ok_or(BiosParseError::SystemManufacturerNotFound),
-        Keyword::SystemProductName => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.product_name())
-            .ok_or(BiosParseError::SystemProductNameNotFound),
-        Keyword::SystemVersion => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.version())
-            .ok_or(BiosParseError::SystemVersionNotFound),
-        Keyword::SystemSerialNumber => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.serial_number())
-            .ok_or(BiosParseError::SystemSerialNumberNotFound),
-        Keyword::SystemUuid => {
-            match data.find_map(|system_info: SMBiosSystemInformation<'_>| system_info.uuid()) {
-                // SystemUuidData is an enum that can be broken down further if desired
-                Some(uuid) => Ok(format!("{:?}", uuid)),
-                None => Err(BiosParseError::SystemUuidNotFound),
-            }
-        }
-        Keyword::SystemSkuNumber => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.sku_number())
-            .ok_or(BiosParseError::SystemSkuNumberNotFound),
-        Keyword::SystemFamily => data
-            .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.family())
-            .ok_or(BiosParseError::SystemFamilyNotFound),
-        Keyword::BaseboardManufacturer => data
-            .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| {
-                baseboard_info.manufacturer()
-            })
-            .ok_or(BiosParseError::BaseboardManufacturerNotFound),
-        Keyword::BaseboardProductName => data
-            .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| baseboard_info.product())
-            .ok_or(BiosParseError::BaseboardProductNameNotFound),
-        Keyword::BaseboardVersion => data
-            .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| baseboard_info.version())
-            .ok_or(BiosParseError::BaseboardVersionNotFound),
-        Keyword::BaseboardSerialNumber => data
-            .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| {
-                baseboard_info.serial_number()
-            })
-            .ok_or(BiosParseError::BaseboardSerialNumberNotFound),
-        Keyword::BaseboardAssetTag => data
-            .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| baseboard_info.asset_tag())
-            .ok_or(BiosParseError::BaseboardAssetTagNotFound),
-        Keyword::ChassisManufacturer => data
-            .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
-                chassis_info.manufacturer()
-            })
-            .ok_or(BiosParseError::ChassisManufacturerNotFound),
-        Keyword::ChassisType => {
-            match data.find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
-                chassis_info.chassis_type()
-            }) {
-                Some(chassis_type) => Ok(format!("{:?}", chassis_type)),
-                None => Err(BiosParseError::ChassisTypeNotFound),
-            }
-        }
-        Keyword::ChassisVersion => data
-            .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| chassis_info.version())
-            .ok_or(BiosParseError::ChassisVersionNotFound),
-        Keyword::ChassisSerialNumber => data
-            .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
-                chassis_info.serial_number()
-            })
-            .ok_or(BiosParseError::ChassisSerialNumberNotFound),
-        Keyword::ChassisAssetTag => data
-            .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
-                chassis_info.asset_tag_number()
-            })
-            .ok_or(BiosParseError::ChassisAssetTagNotFound),
-        Keyword::ProcessorFamily => match data.first::<SMBiosProcessorInformation<'_>>() {
-            Some(processor_info) => match processor_info.processor_family() {
-                Some(family) => match family.value {
-                    ProcessorFamily::SeeProcessorFamily2 => {
-                        match processor_info.processor_family_2() {
-                            Some(family) => Ok(format!("{}", family)),
-                            None => Err(BiosParseError::ProcessorFamilyNotFound),
-                        }
+impl Keyword {
+    pub fn parse(&self, data: &SMBiosData) -> Result<String, BiosParseError> {
+        match self {
+            Keyword::BiosVendor => data
+                .find_map(|bios_info: SMBiosInformation<'_>| bios_info.vendor())
+                .ok_or(BiosParseError::BiosVendorNotFound),
+            Keyword::BiosVersion => data
+                .find_map(|bios_info: SMBiosInformation<'_>| bios_info.version())
+                .ok_or(BiosParseError::BiosVersionNotFound),
+            Keyword::BiosReleaseDate => data
+                .find_map(|bios_info: SMBiosInformation<'_>| bios_info.release_date())
+                .ok_or(BiosParseError::BiosReleaseDateNotFound),
+            Keyword::BiosRevision => data
+                .find_map(|bios_info: SMBiosInformation<'_>| {
+                    match (
+                        bios_info.system_bios_major_release(),
+                        bios_info.system_bios_minor_release(),
+                    ) {
+                        (Some(major), Some(minor)) => Some(format!("{}.{}", major, minor)),
+                        _ => None,
                     }
-                    _ => Ok(format!("{}", family)),
+                })
+                .ok_or(BiosParseError::BiosRevisionNotFound),
+            Keyword::FirmewareRevision => data
+                .find_map(|bios_info: SMBiosInformation<'_>| {
+                    match (
+                        bios_info.e_c_firmware_major_release(),
+                        bios_info.e_c_firmware_minor_release(),
+                    ) {
+                        (Some(major), Some(minor)) => Some(format!("{}.{}", major, minor)),
+                        _ => None,
+                    }
+                })
+                .ok_or(BiosParseError::FirmewareRevisionNotFound),
+            Keyword::SystemManufacturer => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.manufacturer())
+                .ok_or(BiosParseError::SystemManufacturerNotFound),
+            Keyword::SystemProductName => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.product_name())
+                .ok_or(BiosParseError::SystemProductNameNotFound),
+            Keyword::SystemVersion => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.version())
+                .ok_or(BiosParseError::SystemVersionNotFound),
+            Keyword::SystemSerialNumber => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.serial_number())
+                .ok_or(BiosParseError::SystemSerialNumberNotFound),
+            Keyword::SystemUuid => {
+                match data.find_map(|system_info: SMBiosSystemInformation<'_>| system_info.uuid()) {
+                    // SystemUuidData is an enum that can be broken down further if desired
+                    Some(uuid) => Ok(format!("{:?}", uuid)),
+                    None => Err(BiosParseError::SystemUuidNotFound),
+                }
+            }
+            Keyword::SystemSkuNumber => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.sku_number())
+                .ok_or(BiosParseError::SystemSkuNumberNotFound),
+            Keyword::SystemFamily => data
+                .find_map(|system_info: SMBiosSystemInformation<'_>| system_info.family())
+                .ok_or(BiosParseError::SystemFamilyNotFound),
+            Keyword::BaseboardManufacturer => data
+                .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| {
+                    baseboard_info.manufacturer()
+                })
+                .ok_or(BiosParseError::BaseboardManufacturerNotFound),
+            Keyword::BaseboardProductName => data
+                .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| baseboard_info.product())
+                .ok_or(BiosParseError::BaseboardProductNameNotFound),
+            Keyword::BaseboardVersion => data
+                .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| baseboard_info.version())
+                .ok_or(BiosParseError::BaseboardVersionNotFound),
+            Keyword::BaseboardSerialNumber => data
+                .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| {
+                    baseboard_info.serial_number()
+                })
+                .ok_or(BiosParseError::BaseboardSerialNumberNotFound),
+            Keyword::BaseboardAssetTag => data
+                .find_map(|baseboard_info: SMBiosBaseboardInformation<'_>| {
+                    baseboard_info.asset_tag()
+                })
+                .ok_or(BiosParseError::BaseboardAssetTagNotFound),
+            Keyword::ChassisManufacturer => data
+                .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
+                    chassis_info.manufacturer()
+                })
+                .ok_or(BiosParseError::ChassisManufacturerNotFound),
+            Keyword::ChassisType => {
+                match data.find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
+                    chassis_info.chassis_type()
+                }) {
+                    Some(chassis_type) => Ok(format!("{:?}", chassis_type)),
+                    None => Err(BiosParseError::ChassisTypeNotFound),
+                }
+            }
+            Keyword::ChassisVersion => data
+                .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| chassis_info.version())
+                .ok_or(BiosParseError::ChassisVersionNotFound),
+            Keyword::ChassisSerialNumber => data
+                .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
+                    chassis_info.serial_number()
+                })
+                .ok_or(BiosParseError::ChassisSerialNumberNotFound),
+            Keyword::ChassisAssetTag => data
+                .find_map(|chassis_info: SMBiosSystemChassisInformation<'_>| {
+                    chassis_info.asset_tag_number()
+                })
+                .ok_or(BiosParseError::ChassisAssetTagNotFound),
+            Keyword::ProcessorFamily => match data.first::<SMBiosProcessorInformation<'_>>() {
+                Some(processor_info) => match processor_info.processor_family() {
+                    Some(family) => match family.value {
+                        ProcessorFamily::SeeProcessorFamily2 => {
+                            match processor_info.processor_family_2() {
+                                Some(family) => Ok(format!("{}", family)),
+                                None => Err(BiosParseError::ProcessorFamilyNotFound),
+                            }
+                        }
+                        _ => Ok(format!("{}", family)),
+                    },
+                    None => Err(BiosParseError::ProcessorFamilyNotFound),
                 },
                 None => Err(BiosParseError::ProcessorFamilyNotFound),
             },
-            None => Err(BiosParseError::ProcessorFamilyNotFound),
-        },
-        Keyword::ProcessorManufacturer => data
-            .find_map(|processor_info: SMBiosProcessorInformation<'_>| {
-                processor_info.processor_manufacturer()
-            })
-            .ok_or(BiosParseError::ProcessorManufacturerNotFound),
-        Keyword::ProcessorVersion => data
-            .find_map(|processor_info: SMBiosProcessorInformation<'_>| {
-                processor_info.processor_version()
-            })
-            .ok_or(BiosParseError::ProcessorVersionNotFound),
-        Keyword::ProcessorFrequency => {
-            match data.find_map(|processor_info: SMBiosProcessorInformation<'_>| {
-                processor_info.current_speed()
-            }) {
-                Some(current_speed) => Ok(format!("{:?}", current_speed)),
-                None => Err(BiosParseError::ProcessorFrequencyNotFound),
+            Keyword::ProcessorManufacturer => data
+                .find_map(|processor_info: SMBiosProcessorInformation<'_>| {
+                    processor_info.processor_manufacturer()
+                })
+                .ok_or(BiosParseError::ProcessorManufacturerNotFound),
+            Keyword::ProcessorVersion => data
+                .find_map(|processor_info: SMBiosProcessorInformation<'_>| {
+                    processor_info.processor_version()
+                })
+                .ok_or(BiosParseError::ProcessorVersionNotFound),
+            Keyword::ProcessorFrequency => {
+                match data.find_map(|processor_info: SMBiosProcessorInformation<'_>| {
+                    processor_info.current_speed()
+                }) {
+                    Some(current_speed) => Ok(format!("{:?}", current_speed)),
+                    None => Err(BiosParseError::ProcessorFrequencyNotFound),
+                }
             }
         }
     }

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -4,20 +4,6 @@ use crate::error::BiosParseError;
 use smbioslib::*;
 use structopt::StructOpt;
 
-/*
-       Keyword     Types
-       ------------------------------
-       bios        0, 13
-       system      1, 12, 15, 23, 32
-       baseboard   2, 10, 41
-       chassis     3
-       processor   4
-       memory      5, 6, 16, 17
-       cache       7
-       connector   8
-       slot        9
-*/
-
 #[derive(Debug)]
 pub enum BiosType {
     Bios,
@@ -47,6 +33,40 @@ impl FromStr for BiosType {
             "connector" => Ok(BiosType::Connector),
             "slot" => Ok(BiosType::Slot),
             _ => Ok(BiosType::Numeric(u8::from_str(s)?)),
+        }
+    }
+}
+
+/*
+       Keyword     Types
+       ------------------------------
+       bios        0, 13
+       system      1, 12, 15, 23, 32
+       baseboard   2, 10, 41
+       chassis     3
+       processor   4
+       memory      5, 6, 16, 17
+       cache       7
+       connector   8
+       slot        9
+*/
+
+impl IntoIterator for BiosType {
+    type Item = u8;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            BiosType::Bios => vec![0, 13].into_iter(),
+            BiosType::System => vec![1, 12, 15, 23, 32].into_iter(),
+            BiosType::Baseboard => vec![2, 10, 41].into_iter(),
+            BiosType::Chassis => vec![3].into_iter(),
+            BiosType::Processor => vec![4].into_iter(),
+            BiosType::Memory => vec![5, 6, 16, 17].into_iter(),
+            BiosType::Cache => vec![7].into_iter(),
+            BiosType::Connector => vec![8].into_iter(),
+            BiosType::Slot => vec![9].into_iter(),
+            BiosType::Numeric(number) => vec![number].into_iter(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ pub enum BiosParseError {
     BiosVersionNotFound,
     BiosReleaseDateNotFound,
     BiosRevisionNotFound,
-    FirmewareRevisionNotFound,
+    FirmwareRevisionNotFound,
     SystemManufacturerNotFound,
     SystemProductNameNotFound,
     SystemVersionNotFound,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,7 @@
 mod dmiopt;
 mod error;
 
-use crate::dmiopt::opt_string_keyword;
-use dmiopt::Keyword;
+use dmiopt::{BiosType, Keyword};
 use smbioslib::*;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -35,7 +34,11 @@ use structopt::StructOpt;
 */
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "dmidecode", about = "DMI table decoder.")]
+#[structopt(
+    name = "dmidecode-rs",
+    about = "DMI Table Decoder, Rust Edition ⛭",
+    author = "Jeffrey R. Gerber, Juan Zuluaga"
+)]
 struct Opt {
     /// Less verbose output
     // short and long flags (-q, --quiet) will be deduced from the field's name
@@ -53,6 +56,10 @@ struct Opt {
     /// Dump the DMI data to a binary file
     #[structopt(long = "dump-bin", parse(from_os_str))]
     output: Option<PathBuf>,
+
+    /// Only display the entries of given type
+    #[structopt(short = "t", long = "type")]
+    bios_type: Vec<BiosType>,
 }
 
 impl Opt {
@@ -63,7 +70,7 @@ impl Opt {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt: Opt = Opt::from_args();
-
+    println!("{:?}", opt);
     if opt.has_no_args() {
         println!("{:#X?}", table_load_from_device()?);
         return Ok(());
@@ -72,7 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match opt.keyword {
         Some(keyword) => {
             let smbios_data = table_load_from_device()?;
-            let output = opt_string_keyword(keyword, &smbios_data)?;
+            let output = keyword.parse(&smbios_data)?;
             println!("{}", output);
         }
         None => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,22 @@ struct Opt {
     output: Option<PathBuf>,
 
     /// Only display the entries of given type
-    #[structopt(short = "t", long = "type")]
+    ///
+    /// Supply one or more keywords, one or more type values,
+    /// or a combination of the two.
+    ///
+    ///    Keyword     Types
+    ///    ------------------------------
+    ///    bios        0, 13
+    ///    system      1, 12, 15, 23, 32
+    ///    baseboard   2, 10, 41
+    ///    chassis     3
+    ///    processor   4
+    ///    memory      5, 6, 16, 17
+    ///    cache       7
+    ///    connector   8
+    ///    slot        9
+    #[structopt(short = "t", long = "type", verbatim_doc_comment)]
     bios_types: Option<Vec<BiosType>>,
 
     /// List supported DMI string

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,28 @@ struct Opt {
     #[structopt(short, long)]
     quiet: bool,
 
-    /// Only display the value of the given DMI string
+    /// Only display the value of the DMI string identified by `keyword`.
+    ///
+    /// KEYWORD must be a keyword from the following list: bios-vendor,
+    /// bios-version, bios-release-date, system-manufacturer, system-
+    /// product-name, system-version, system-serial-number, system-uuid,
+    /// system-family, baseboard-manufacturer, baseboard-product-name,
+    /// baseboard-version, baseboard-serial-number, baseboard-asset-tag,
+    /// chassis-manufacturer, chassis-type, chassis-version, chassis-
+    /// serial-number, chassis-asset-tag, processor-family, processor-
+    /// manufacturer, processor-version, processor-frequency.  Each
+    /// keyword corresponds to a given DMI type and a given offset
+    /// within this entry type.  Not all strings may be meaningful or
+    /// even defined on all systems. Some keywords may return more than
+    /// one result on some systems (e.g.  processor-version on a multi-
+    /// processor system).  If KEYWORD is not provided or not valid, a
+    /// list of all valid keywords is printed and dmidecode exits with
+    /// an error.  This option cannot be used more than once.
+    ///
+    /// Note: on Linux, most of these strings can alternatively be read
+    /// directly from sysfs, typically from files under
+    /// /sys/devices/virtual/dmi/id.  Most of these files are even
+    /// readable by regular users.    
     #[structopt(short = "s", long = "string")]
     keyword: Option<Keyword>,
 


### PR DESCRIPTION
It allows multiple types on the command line like this.  Note the elipsis ...
```
     Running `target\debug\dmidecode.exe --help`
dmidecode-rs 0.1.0
Jeffrey R. Gerber, Juan Zuluaga
DMI Table Decoder, Rust Edition ⛭

USAGE:
    dmidecode.exe [FLAGS] [OPTIONS]

FLAGS:
    -h, --help
            Prints help information

    -l, --list
            List supported DMI string

    -q, --quiet
            Less verbose output

    -V, --version
            Prints version information


OPTIONS:
    -t, --type <bios-types>...
            Only display the entries of given type

            Supply one or more keywords, one or more type values,
            or a combination of the two.

               Keyword     Types
               ------------------------------
               bios        0, 13
               system      1, 12, 15, 23, 32
               baseboard   2, 10, 41
               chassis     3
               processor   4
               memory      5, 6, 16, 17
               cache       7
               connector   8
               slot        9
        --from-dump <input>
            Read the DMI data from a binary file

    -s, --string <keyword>
            Only display the value of the given DMI string

        --dump-bin <output>
            Dump the DMI data to a binary file

```

Here's an example using it, take note of the mix of options for bios_types:
```
Running `target\debug\dmidecode.exe -t bios 7 1 slot 3`
Opt { quiet: false, keyword: None, input: None, output: None, bios_types: Some([Bios, Numeric(7), Numeric(1), Slot, Numeric(3)]) }
CacheInformation(
    smbioslib::structs::types::cache_information::SMBiosCacheInformation {
        header: smbioslib::core::header::Header {
            struct_type: 0x7,
            length: 0x1B,
            handle: smbioslib::structs::structure::Handle {
                handle: 0x3,
```

Also, the input now can be selected as a file with the various output options:
```
     Running `target\debug\dmidecode.exe --from-dump abc.dat -t bios`
Information(
    smbioslib::structs::types::bios_information::SMBiosInformation {
        header: smbioslib::core::header::Header {
            struct_type: 0x0,
            length: 0x1A,
...
```