### PR TITLE
Add initial integration tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: dmidecode-rs
+name: dmidecode-rs-linux
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ path = "src/main.rs"
 structopt = { version = "0.3", default-features = true }
 smbios = { git = "https://github.com/jrgerber/smbios-lib", branch = "main" }
 enum-iterator = "0.6.0"
+
+[dev-dependencies]
+assert_cmd = "1.0.3"
+predicates = "1.0.7"
+tempfile = "3.2.0"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,3 +52,26 @@ fn test_dump_bin_read_bin() -> Result<(), Box<dyn std::error::Error>> {
     dir.close()?;
     Ok(())
 }
+
+#[test]
+fn test_dmi_str_no_value() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(CLI_COMMAND)?;
+    cmd.arg("-s");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("requires a value"));
+    Ok(())
+}
+
+#[test]
+fn test_dmi_str_known_unknown_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd1.arg("-s").arg("bios-version");
+    cmd1.assert().success();
+
+    let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd2.arg("-s").arg("invalid");
+    cmd2.assert().failure().stderr(predicate::str::contains("Invalid value"));
+
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,54 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+use tempfile::tempdir;
+
+
+static CLI_COMMAND: &str = "dmidecode";
+
+#[test]
+fn test_command_run() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin(CLI_COMMAND)?;
+    Ok(())
+}
+
+#[test]
+fn test_dump_bin_no_value() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(CLI_COMMAND)?;
+
+    cmd.arg("--dump-bin");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("requires a value"));
+    Ok(())
+}
+
+#[test]
+fn test_read_bin_no_value() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(CLI_COMMAND)?;
+
+    cmd.arg("--from-dump");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("requires a value"));
+    Ok(())
+}
+
+#[test]
+fn test_dump_bin_read_bin() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd_dump = Command::cargo_bin(CLI_COMMAND)?;
+    let dir = tempdir()?;
+
+    let filename = dir.path().join("raw.bin");
+    let filename_str = filename.to_str().unwrap();
+    cmd_dump.arg("--dump-bin").arg(&filename_str);
+    cmd_dump.assert().success();
+
+    let mut cmd_read = Command::cargo_bin(CLI_COMMAND)?;
+    cmd_read.arg("--from-dump").arg(&filename_str);
+    cmd_read.assert().success();
+
+    drop(filename);
+    dir.close()?;
+    Ok(())
+}


### PR DESCRIPTION
Close #8 
Example of the output of some of the tests:
```sh
$cargo test
...
    Finished test [unoptimized + debuginfo] target(s) in 0.89s
     Running target/debug/deps/dmidecode-082c1f84ec629d76

running 2 tests
test dmiopt::test_enum_display_exist_in_opt_string_keyword ... ok
test dmiopt::test_keyword_invalid_error_expected ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/debug/deps/cli-4e6c2271ce6ee386

running 4 tests
test test_command_run ... ok
test test_read_bin_no_value ... ok
test test_dump_bin_no_value ... ok
test test_dump_bin_read_bin ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

```