### PR TITLE
Impl oem-strings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: dmidecode-rs-linux
+name: linux
 
 on:
   push:

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -71,7 +71,9 @@ fn test_dmi_str_known_unknown_keyword() -> Result<(), Box<dyn std::error::Error>
 
     let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
     cmd2.arg("-s").arg("invalid");
-    cmd2.assert().failure().stderr(predicate::str::contains("Invalid value"));
+    cmd2.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid value"));
 
     Ok(())
 }
@@ -80,11 +82,15 @@ fn test_dmi_str_known_unknown_keyword() -> Result<(), Box<dyn std::error::Error>
 fn test_oem_string_invalid() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
     cmd1.arg("--oem-string").arg("0");
-    cmd1.assert().failure().stderr(predicate::str::contains("Invalid OEM string number 0"));
+    cmd1.assert()
+        .failure()
+        .stderr(predicate::str::contains("string number 0"));
 
     let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
     cmd2.arg("--oem-string").arg("foo");
-    cmd2.assert().failure().stderr(predicate::str::contains("Invalid OEM string number foo"));
+    cmd2.assert()
+        .failure()
+        .stderr(predicate::str::contains("string number foo"));
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -75,3 +75,29 @@ fn test_dmi_str_known_unknown_keyword() -> Result<(), Box<dyn std::error::Error>
 
     Ok(())
 }
+
+#[test]
+fn test_oem_string_invalid() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd1.arg("--oem-string").arg("0");
+    cmd1.assert().failure().stderr(predicate::str::contains("Invalid OEM string number 0"));
+
+    let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd2.arg("--oem-string").arg("foo");
+    cmd2.assert().failure().stderr(predicate::str::contains("Invalid OEM string number foo"));
+
+    Ok(())
+}
+
+#[test]
+fn test_oem_string_valid() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd1.arg("--oem-string").arg("1");
+    cmd1.assert().success();
+
+    let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd2.arg("--oem-string").arg("count");
+    cmd2.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
Close #27 
Tested on ubuntu vm:
```sh
sudo -E target/debug/dmidecode --oem-string count
2
sudo -E target/debug/dmidecode --oem-string 1
vboxVer_6.1.18
sudo -E target/debug/dmidecode --oem-string 2
vboxRev_142142
sudo -E target/debug/dmidecode --oem-string 0
Error: Custom { kind: InvalidInput, error: "Invalid OEM string number 0" }
```