### PR TITLE
Make entry point output identical to dmidecode original

### DIFF
--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -43,7 +43,7 @@ pub struct Opt {
     /// Note: on Linux, most of these strings can alternatively be read
     /// directly from sysfs, typically from files under
     /// /sys/devices/virtual/dmi/id.  Most of these files are even
-    /// readable by regular users.    
+    /// readable by regular users.
     #[structopt(short = "s", long = "string")]
     pub keyword: Option<Keyword>,
 

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -120,6 +120,11 @@ impl Opt {
     }
 }
 
+/// Prints the dmidecode version to stdout
+pub fn print_dmidecode_version() {
+    println!("# {} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum BiosType {
     Bios,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,16 +63,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         opt.undefined_dump,
         opt.list,
     ) {
+        // opt.keyword, -s, --string KEYWORD   Only display the value of the given DMI string
         (Some(keyword), None, None, None, None, false, false) => {
             let output = keyword.parse(&smbios_data)?;
             println!("{}", output);
         }
+        // opt.output, --dump-bin FILE    Dump the DMI data to a binary file
         (None, Some(output), None, None, None, false, false) => {
             dump_raw(raw_smbios_from_device()?, &output.as_path())?
         }
+        // opt.bios_types, -t, --type TYPE        Only display the entries of given type
         (None, None, Some(bios_types), None, None, false, false) => {
             BiosType::parse_and_display(bios_types, &smbios_data);
         }
+        // opt.handle, -H, --handle HANDLE    Only display the entry of given handle
         (None, None, None, Some(handle), None, false, false) => {
             let found_struct = smbios_data
                 .find_by_handle(&handle)
@@ -82,6 +86,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ))?;
             println!("{:#X?}", &found_struct.defined_struct())
         }
+        // opt.oem_string, --oem-string N     Only display the value of the given OEM string
         (None, None, None, None, Some(oem), false, false) => {
             fn invalid_num(s: &str) -> Result<(), Box<dyn std::error::Error>> {
                 Err(Box::new(std::io::Error::new(
@@ -120,6 +125,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 None => invalid_num(oem.as_str())?,
             }
         }
+        // opt.undefined_dump, -u, --dump             Do not decode the entries
         (None, None, None, None, None, true, false) => {
             for undefined_struct in smbios_data {
                 /*
@@ -167,6 +173,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!();
             }
         }
+        // opt.list, -l, --list        List supported DMI string
         (None, None, None, None, None, false, true) => {
             for i in Keyword::into_enum_iter() {
                 println!("{}", &i);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod platform;
 mod dmiopt;
 mod error;
 
-use dmiopt::{BiosType, Keyword, Opt};
+use dmiopt::{print_dmidecode_version, BiosType, Keyword, Opt};
 use enum_iterator::IntoEnumIterator;
 use smbioslib::*;
 use structopt::StructOpt;
@@ -40,6 +40,8 @@ use structopt::StructOpt;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt: Opt = Opt::from_args();
+
+    print_dmidecode_version();
 
     if opt.has_no_args() {
         println!("{:#X?}", platform::table_load(&opt)?);
@@ -142,6 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 31 32 2F 30 37 2F 32 30 31 38 00
                                 "12/07/2018"
                 */
+                println!();
                 println!(
                     "Handle {:#06X}, DMI type {}, {} bytes",
                     *undefined_struct.header.handle(),
@@ -159,7 +162,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!();
                 print!("\tStrings:");
                 for string_item in undefined_struct.strings.iter() {
-                    for item in string_item.iter().enumerate() {
+                    // chain() adds a terminating \0 for parity with the original dmidecode
+                    for item in string_item.iter().chain([0].iter()).enumerate() {
                         if item.0 % 16 == 0 {
                             println!();
                             print!("\t\t");

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,25 +1,96 @@
 use crate::Opt;
 use io::{Error, ErrorKind};
 use smbioslib::*;
+use std::fmt::Write;
 
 mod dmiopt;
 
 #[cfg(target_os = "linux")]
 pub fn table_load(opt: &Opt) -> Result<SMBiosData, Error> {
-    if opt.no_sysfs {
-        // read from /dev/mem
-        return table_load_from_dev_mem();
+    if !opt.no_sysfs {
+        // read from /sys/firmware/dmi/tables/DMI
+        if let Ok(smbios_data) = table_load_from_sysfs() {
+            return Ok(smbios_data);
+        }
     }
 
-    // read from /sys/firmware/dmi/tables/DMI
-    println!("Getting SMBIOS data from sysfs.");
-    table_load_from_device()
+    // read from /dev/mem
+    table_load_from_dev_mem()
 }
 
 #[cfg(target_os = "freebsd")]
 pub fn table_load(_opt: &Opt) -> Result<SMBiosData, Error> {
     // FreeBSD only has /dev/mem and does not have sysfs (/sys/firmware/dmi/tables/DMI)
     table_load_from_dev_mem()
+}
+
+/// Load from /sys/firmware/dmi/tables/DMI
+fn table_load_from_sysfs() -> Result<SMBiosData, Error> {
+    let mut output = String::new();
+
+    writeln!(&mut output, "Getting SMBIOS data from sysfs.").unwrap();
+
+    let version: SMBiosVersion;
+    let entry_path = std::path::Path::new(SYS_ENTRY_FILE);
+
+    match SMBiosEntryPoint64::try_load_from_file(entry_path) {
+        Ok(entry_point) => {
+            version = SMBiosVersion {
+                major: entry_point.major_version(),
+                minor: entry_point.minor_version(),
+                revision: entry_point.docrev(),
+            };
+
+            writeln!(
+                &mut output,
+                "SMBIOS {}.{}.{} present.",
+                entry_point.major_version(),
+                entry_point.minor_version(),
+                entry_point.docrev()
+            )
+            .unwrap();
+
+            writeln!(
+                &mut output,
+                "Occupying {} bytes maximum.",
+                entry_point.structure_table_maximum_size()
+            )
+            .unwrap()
+        }
+        Err(err) => match err.kind() {
+            ErrorKind::InvalidData => match SMBiosEntryPoint32::try_load_from_file(entry_path) {
+                Ok(entry_point) => {
+                    version = SMBiosVersion {
+                        major: entry_point.major_version(),
+                        minor: entry_point.minor_version(),
+                        revision: 0,
+                    };
+
+                    writeln!(
+                        &mut output,
+                        "SMBIOS {}.{} present.",
+                        entry_point.major_version(),
+                        entry_point.minor_version()
+                    )
+                    .unwrap();
+
+                    writeln!(
+                        &mut output,
+                        "{} structures occupying {} bytes.",
+                        entry_point.number_of_smbios_structures(),
+                        entry_point.structure_table_length()
+                    )
+                    .unwrap()
+                }
+                Err(err) => return Err(err),
+            },
+            _ => return Err(err),
+        },
+    }
+
+    print!("{}", output);
+
+    SMBiosData::try_load_from_file(SYS_TABLE_FILE, Some(version))
 }
 
 /// Load from /dev/mem
@@ -30,7 +101,11 @@ fn table_load_from_dev_mem() -> Result<SMBiosData, Error> {
     let structure_table_address: u64;
     let structure_table_length: u32;
     let version: SMBiosVersion;
+    let mut output = String::new();
 
+    writeln!(&mut output, "Scanning /dev/mem for entry point.").unwrap();
+
+    // First try 32 bit entry point
     match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END) {
         Ok(entry_point) => {
             structure_table_address = entry_point.structure_table_address() as u64;
@@ -41,20 +116,25 @@ fn table_load_from_dev_mem() -> Result<SMBiosData, Error> {
                 revision: 0,
             };
 
-            println!("Scanning /dev/mem for entry point.");
-            println!(
+            writeln!(
+                &mut output,
                 "SMBIOS {}.{} present.",
                 entry_point.major_version(),
                 entry_point.minor_version()
-            );
-            println!(
+            )
+            .unwrap();
+
+            writeln!(
+                &mut output,
                 "{} structures occupying {} bytes.",
                 entry_point.number_of_smbios_structures(),
                 entry_point.structure_table_length()
-            );
-            println!("Table at: {:#010X}.", entry_point.structure_table_address());
+            )
+            .unwrap();
         }
         Err(error) => {
+            // UnexpectedEof means the 32 bit entry point was not found and
+            // the 64 bit entry point can be tried next.  Any other failure we report.
             if error.kind() != ErrorKind::UnexpectedEof {
                 return Err(error);
             }
@@ -70,19 +150,25 @@ fn table_load_from_dev_mem() -> Result<SMBiosData, Error> {
                 revision: entry_point.docrev(),
             };
 
-            println!(
+            writeln!(
+                &mut output,
                 "SMBIOS {}.{}.{} present.",
                 entry_point.major_version(),
                 entry_point.minor_version(),
                 entry_point.docrev()
-            );
-            println!(
+            )
+            .unwrap();
+
+            writeln!(
+                &mut output,
                 "Occupying {} bytes maximum.",
                 entry_point.structure_table_maximum_size()
-            );
-            println!("Table at: {:#010X}.", entry_point.structure_table_address());
+            )
+            .unwrap();
         }
     }
+
+    writeln!(&mut output, "Table at: {:#010X}.", structure_table_address).unwrap();
 
     if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
         return Err(Error::new(
@@ -109,6 +195,8 @@ fn table_load_from_dev_mem() -> Result<SMBiosData, Error> {
         structure_table_address,
         structure_table_length as usize,
     )?;
+
+    print!("{}", output);
 
     Ok(SMBiosData::new(table, Some(version)))
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -55,7 +55,14 @@ fn table_load_from_sysfs() -> Result<SMBiosData, Error> {
                 "Occupying {} bytes maximum.",
                 entry_point.structure_table_maximum_size()
             )
-            .unwrap()
+            .unwrap();
+
+            writeln!(
+                &mut output,
+                "Table at: {:#010X}.",
+                entry_point.structure_table_address()
+            )
+            .unwrap();
         }
         Err(err) => match err.kind() {
             ErrorKind::InvalidData => match SMBiosEntryPoint32::try_load_from_file(entry_path) {
@@ -80,7 +87,14 @@ fn table_load_from_sysfs() -> Result<SMBiosData, Error> {
                         entry_point.number_of_smbios_structures(),
                         entry_point.structure_table_length()
                     )
-                    .unwrap()
+                    .unwrap();
+
+                    writeln!(
+                        &mut output,
+                        "Table at: {:#010X}.",
+                        entry_point.structure_table_address()
+                    )
+                    .unwrap();
                 }
                 Err(err) => return Err(err),
             },


### PR DESCRIPTION
dmidecode rust output now looks identical to dmidecode original (except for its version):
```
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode -u|more
# dmidecode-rs 0.1.0
Getting SMBIOS data from sysfs.
SMBIOS 2.3 present.
338 structures occupying 17307 bytes.
Table at: 0x000F93D0.

Handle 0x0000, DMI type 0, 20 bytes
        Header and Data:
                00 14 00 00 01 02 00 F0 03 03 90 DA CB 7F 00 00
                00 00 34 01
        Strings:
                41 6D 65 72 69 63 61 6E 20 4D 65 67 61 74 72 65
                6E 64 73 20 49 6E 63 2E 00
                "American Megatrends Inc."
                30 39 30 30 30 38 20 00
                "090008 "
                31 32 2F 30 37 2F 32 30 31 38 00
                "12/07/2018"

Handle 0x0001, DMI type 1, 25 bytes
        Header and Data:
                01 19 01 00 01 02 03 04 48 EB BE 42 FE F7 E6 49
                90 EC B0 24 49 F0 C8 28 06
        Strings:
                4D 69 63 72 6F 73 6F 66 74 20 43 6F 72 70 6F 72
                61 74 69 6F 6E 00
                "Microsoft Corporation"
                56 69 72 74 75 61 6C 20 4D 61 63 68 69 6E 65 00
                "Virtual Machine"
...
```

dmidecode original:
```
root@UbuntuRust:~/dmidecode-rs/target/debug# dmidecode -u|more
# dmidecode 3.1
Getting SMBIOS data from sysfs.
SMBIOS 2.3 present.
338 structures occupying 17307 bytes.
Table at 0x000F93D0.

Handle 0x0000, DMI type 0, 20 bytes
        Header and Data:
                00 14 00 00 01 02 00 F0 03 03 90 DA CB 7F 00 00
                00 00 34 01
        Strings:
                41 6D 65 72 69 63 61 6E 20 4D 65 67 61 74 72 65
                6E 64 73 20 49 6E 63 2E 00
                "American Megatrends Inc."
                30 39 30 30 30 38 20 00
                "090008 "
                31 32 2F 30 37 2F 32 30 31 38 00
                "12/07/2018"

Handle 0x0001, DMI type 1, 25 bytes
        Header and Data:
                01 19 01 00 01 02 03 04 48 EB BE 42 FE F7 E6 49
                90 EC B0 24 49 F0 C8 28 06
        Strings:
                4D 69 63 72 6F 73 6F 66 74 20 43 6F 72 70 6F 72
                61 74 69 6F 6E 00
                "Microsoft Corporation"
                56 69 72 74 75 61 6C 20 4D 61 63 68 69 6E 65 00
                "Virtual Machine"
...
```

Also:
1. Now if linux fails to retrieve from sysfs, it will try from /dev/mem before failing.
2. Output will now only print from the method which succeeds (if sysfs fails, the output won't be seen)
3. The original dmidecode -u option displayed a terminating zero of each string.  We were leaving out the zero after parsing, the zero is added back in for identical looking output.

Not covered:
MacOS and Windows.  MacOS can look identical to the above because it reads both the entry point and table.  Testing for me is a challenge on MacOS at the moment.  Windows does not have the entry point structure so it is not possible to make the exact output as above (I believe XP and below is the only place it can be done with direct memory access).