### PR TITLE
Implement -d, --dev-mem FILE

### DIFF
--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -22,6 +22,10 @@ pub struct Opt {
     #[structopt(short, long)]
     pub quiet: bool,
 
+    /// Read memory from device FILE (default: /dev/mem)
+    #[structopt(short, long, parse(from_os_str))]
+    pub dev_mem: Option<PathBuf>,
+
     /// Only display the value of the DMI string identified by `keyword`.
     ///
     /// `keyword` must be a keyword from the following list: bios-vendor,

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -23,7 +23,7 @@ pub struct Opt {
     pub quiet: bool,
 
     /// Read memory from device FILE (default: /dev/mem)
-    #[structopt(short, long, parse(from_os_str))]
+    #[structopt(short, long, name = "FILE", parse(from_os_str))]
     pub dev_mem: Option<PathBuf>,
 
     /// Only display the value of the DMI string identified by `keyword`.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -18,7 +18,7 @@ pub fn table_load(opt: &Opt) -> Result<SMBiosData, Error> {
     // read from /dev/mem (default) or a given device file.
     let path = match &opt.dev_mem {
         Some(given_file) => given_file.as_path(),
-        None => std::path::Path::new(SYS_ENTRY_FILE),
+        None => std::path::Path::new(DEV_MEM_FILE),
     };
     let smbios_data = table_load_from_dev_mem(&path)?;
 
@@ -29,7 +29,11 @@ pub fn table_load(opt: &Opt) -> Result<SMBiosData, Error> {
 #[cfg(target_os = "freebsd")]
 pub fn table_load(_opt: &Opt) -> Result<SMBiosData, Error> {
     // FreeBSD only has /dev/mem and does not have sysfs (/sys/firmware/dmi/tables/DMI)
-    let smbios_data = table_load_from_dev_mem()?;
+    let path = match &opt.dev_mem {
+        Some(given_file) => given_file.as_path(),
+        None => std::path::Path::new(DEV_MEM_FILE),
+    };
+    let smbios_data = table_load_from_dev_mem(&path)?;
 
     print!("{}", smbios_data.1);
     Ok(smbios_data.0)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,7 @@
 use crate::Opt;
 use io::{Error, ErrorKind};
 use smbioslib::*;
-use std::fmt::Write;
+use std::{fmt::Write, path::Path};
 
 mod dmiopt;
 
@@ -15,8 +15,12 @@ pub fn table_load(opt: &Opt) -> Result<SMBiosData, Error> {
         }
     }
 
-    // read from /dev/mem
-    let smbios_data = table_load_from_dev_mem()?;
+    // read from /dev/mem (default) or a given device file.
+    let path = match &opt.dev_mem {
+        Some(given_file) => given_file.as_path(),
+        None => std::path::Path::new(SYS_ENTRY_FILE),
+    };
+    let smbios_data = table_load_from_dev_mem(&path)?;
 
     print!("{}", smbios_data.1);
     Ok(smbios_data.0)
@@ -115,16 +119,21 @@ fn table_load_from_sysfs() -> Result<(SMBiosData, String), Error> {
 }
 
 /// Load from /dev/mem
-fn table_load_from_dev_mem() -> Result<(SMBiosData, String), Error> {
+fn table_load_from_dev_mem(path: &Path) -> Result<(SMBiosData, String), Error> {
     const RANGE_START: u64 = 0x000F0000u64;
     const RANGE_END: u64 = 0x000FFFFFu64;
-    let mut dev_mem = fs::File::open(DEV_MEM_FILE)?;
+    let mut dev_mem = fs::File::open(path)?;
     let structure_table_address: u64;
     let structure_table_length: u32;
     let version: SMBiosVersion;
     let mut output = String::new();
 
-    writeln!(&mut output, "Scanning /dev/mem for entry point.").unwrap();
+    writeln!(
+        &mut output,
+        "Scanning {} for entry point.",
+        path.to_string_lossy()
+    )
+    .unwrap();
 
     // First try 32 bit entry point
     match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -116,3 +116,21 @@ fn test_no_sysfs() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[test]
+fn test_dev_mem() -> Result<(), Box<dyn std::error::Error>> {
+    // test good path to /dev/mem
+    let mut cmd = Command::cargo_bin(CLI_COMMAND)?;
+    cmd.arg("--no-sysfs").arg("--dev-mem").arg("/dev/mem");
+    cmd.assert().success();
+
+    // test bad path to /dev/memx
+    cmd = Command::cargo_bin(CLI_COMMAND)?;
+    cmd.arg("--no-sysfs").arg("--dev-mem").arg("/dev/memx");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("No such file or directory"));
+
+    Ok(())
+}


### PR DESCRIPTION
Appearance in help:
```
OPTIONS:
    -d, --dev-mem <FILE>
            Read memory from device FILE (default: /dev/mem)
```

It replaces the value for /dev/mem.  If a device does not use /dev/mem, this option alone does nothing.  On sysfs devices you must use --no-sysfs for this option to be useful.

Example 1: use a bad path.
```
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode --no-sysfs --dev-mem /dev/memx -u|more
# dmidecode-rs 0.1.0
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
Example 2: use a good path.
```
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode --no-sysfs --dev-mem /dev/mem -u|more
# dmidecode-rs 0.1.0
Scanning /dev/mem for entry point.
SMBIOS 2.3 present.
```

Example 3: use a bad path on a sysfs system without using --no-sysfs:
```
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode --dev-mem /dev/memx -u|more
# dmidecode-rs 0.1.0
Getting SMBIOS data from sysfs.
SMBIOS 2.3 present.
```

Example 4: Read files that do exist but are not real /dev/mem files:
```
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode --no-sysfs --dev-mem ./dmidecode|more
# dmidecode-rs 0.1.0
Error: Custom { kind: UnexpectedEof, error: "Not found" }
root@UbuntuRust:~/dmidecode-rs/target/debug# ./dmidecode --no-sysfs --dev-mem /sys/firmware/dmi/tables/DMI|more
# dmidecode-rs 0.1.0
Error: Custom { kind: UnexpectedEof, error: "failed to fill whole buffer" }
```