### PR TITLE
Add JSON command line option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 
 [dependencies]
 structopt = { version = "0.3", default-features = true }
-smbios-lib = "0.7.3"
+smbios-lib = "0.7.4"
 enum-iterator = "0.6.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -110,11 +110,12 @@ pub struct Opt {
     pub no_sysfs: bool,
 
     /// Display output in JSON pretty print format.
+    #[structopt(long)]
+    pub json_pretty: bool,
+
+    /// Display output in JSON compact format.
     #[structopt(short, long)]
     pub json: bool,
-    /// Display output in JSON compact format.
-    #[structopt(long)]
-    pub json_compact: bool,
 }
 
 impl Opt {
@@ -128,8 +129,8 @@ impl Opt {
             && !self.no_sysfs
             && !self.undefined_dump
             && !self.list
+            && !self.json_pretty
             && !self.json
-            && !self.json_compact
     }
 }
 

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -108,6 +108,13 @@ pub struct Opt {
     /// This is mainly useful for debugging.
     #[structopt(long = "no-sysfs")]
     pub no_sysfs: bool,
+
+    /// Display output in JSON pretty print format.
+    #[structopt(short, long)]
+    pub json: bool,
+    /// Display output in JSON compact format.
+    #[structopt(long)]
+    pub json_compact: bool,
 }
 
 impl Opt {
@@ -121,6 +128,8 @@ impl Opt {
             && !self.no_sysfs
             && !self.undefined_dump
             && !self.list
+            && !self.json
+            && !self.json_compact
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         opt.oem_string,
         opt.undefined_dump,
         opt.list,
+        opt.json_pretty,
         opt.json,
-        opt.json_compact,
     ) {
         // opt.keyword, -s, --string KEYWORD   Only display the value of the given DMI string
         (Some(keyword), None, None, None, None, false, false, false, false) => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -97,12 +97,13 @@ fn test_oem_string_invalid() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_oem_string_valid() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
-    cmd1.arg("--oem-string").arg("1");
+    cmd1.arg("--oem-string").arg("count");
     cmd1.assert().success();
 
-    let mut cmd2 = Command::cargo_bin(CLI_COMMAND)?;
-    cmd2.arg("--oem-string").arg("count");
-    cmd2.assert().success();
+    // TODO: Learn how to capture stdout from cmd1.  If it is "0", do not run cmd2.
+    let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd1.arg("--oem-string").arg("1");
+    cmd1.assert().success();
 
     Ok(())
 }
@@ -148,7 +149,9 @@ fn test_dump_opt() -> Result<(), Box<dyn std::error::Error>> {
 fn test_handle_valid() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
     cmd1.arg("-H").arg("10");
-    cmd1.assert().success().stdout(predicate::str::contains("0xA"));
+    cmd1.assert()
+        .success()
+        .stdout(predicate::str::contains("10"));
 
     Ok(())
 }
@@ -160,6 +163,17 @@ fn test_handle_invalid() -> Result<(), Box<dyn std::error::Error>> {
     cmd1.assert()
         .failure()
         .stderr(predicate::str::contains("Handle not found: 1000"));
+
+    Ok(())
+}
+
+#[test]
+fn test_json_valid() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd1 = Command::cargo_bin(CLI_COMMAND)?;
+    cmd1.arg("-j");
+    cmd1.assert()
+        .success()
+        .stdout(predicate::str::contains("{\"version\":{\"major\":"));
 
     Ok(())
 }


### PR DESCRIPTION
```
Running `target\debug\dmidecode.exe --json-compact`
{"version":{"major":3,"minor":3,"revision":0},"table":[{"MemoryErrorInformation32Bit":{"header":{"struct_type":18,"length":23,"handle":0},"error_type":{"raw":3,"value":"OK"},"error_granularity":{"raw":2,"value":"Unknown"},"error_operation":{"raw":2,"value":"Unknown"},"vendor_syndrome":0,"memory_array_error_address":2147483648,"device_error_address":2147483648,"error_resolution":2147483648}},{"PhysicalMemoryArray":{"header":{"struct_type":16,"length":23,"handle":1},"location":{"raw":3,"value":"SystemBoardOrMotherboard"},"usage":{"raw":3,"value":"SystemMemory"},"memory_error_correction":{"raw":3,"value":"NoCorrection"},"maximum_capacity":{"Kil

etc.
```