### PR TITLE
AMD: Fix wrong family reported in processor signature.

### DIFF
--- a/src/dmifn.rs
+++ b/src/dmifn.rs
@@ -585,7 +585,7 @@ pub fn dmi_processor_id(data: &SMBiosProcessorInformation<'_>) {
                             eax & 0xF
                         );
                     }
-                    // AMD
+                    // AMD, publication #25481 revision 2.28
                     2 => {
                         println!(
                             "\tSignature: Family {}, Model {}, Stepping {}",

--- a/src/dmifn.rs
+++ b/src/dmifn.rs
@@ -589,15 +589,14 @@ pub fn dmi_processor_id(data: &SMBiosProcessorInformation<'_>) {
                     2 => {
                         println!(
                             "\tSignature: Family {}, Model {}, Stepping {}",
-                            (eax >> 8)
-                                & 0xF
+                            ((eax >> 8) & 0xF)
                                     + match ((eax >> 8) & 0xF) == 0xF {
-                                        true => (eax >> 20) & 0xFF,
+                                        true => ((eax >> 20) & 0xFF),
                                         false => 0,
                                     },
-                            (eax >> 4) & 0xF
+                            ((eax >> 4) & 0xF)
                                 | match ((eax >> 8) & 0xF) == 0xF {
-                                    true => (eax >> 12) & 0xF0,
+                                    true => ((eax >> 12) & 0xF0),
                                     false => 0,
                                 },
                             eax & 0xF

--- a/src/dmifn.rs
+++ b/src/dmifn.rs
@@ -590,13 +590,13 @@ pub fn dmi_processor_id(data: &SMBiosProcessorInformation<'_>) {
                         println!(
                             "\tSignature: Family {}, Model {}, Stepping {}",
                             ((eax >> 8) & 0xF)
-                                    + match ((eax >> 8) & 0xF) == 0xF {
-                                        true => ((eax >> 20) & 0xFF),
-                                        false => 0,
-                                    },
+                                + match ((eax >> 8) & 0xF) == 0xF {
+                                    true => (eax >> 20) & 0xFF,
+                                    false => 0,
+                                },
                             ((eax >> 4) & 0xF)
                                 | match ((eax >> 8) & 0xF) == 0xF {
-                                    true => ((eax >> 12) & 0xF0),
+                                    true => (eax >> 12) & 0xF0,
                                     false => 0,
                                 },
                             eax & 0xF


### PR DESCRIPTION
& has lower operator precedence than +, so we need parens to correctly capture the base family before adding to extended family. I also made these a bit more explicitly paren'd although we were not affected in model.

Fixes reporting Family 7, when it should report Family 23. 