### PR TITLE
Remove address check for smbios structure table. Can be at any address

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -199,16 +199,6 @@ fn table_load_from_dev_mem(path: &Path) -> Result<(SMBiosData, String), Error> {
 
     writeln!(&mut output, "Table at: {:#010X}.", structure_table_address).unwrap();
 
-    if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            format!(
-                "The entry point has given an out of range start address for the table: {}",
-                structure_table_address
-            ),
-        ));
-    }
-
     if structure_table_address + structure_table_length as u64 > RANGE_END {
         return Err(Error::new(
             ErrorKind::InvalidData,


### PR DESCRIPTION
Only the entry point must live in this range.