### PR TITLE
Dmidecode output matching

### DIFF
--- a/src/default_out.rs
+++ b/src/default_out.rs
@@ -38,6 +38,7 @@ pub fn default_dump(smbios_data: &SMBiosData, quiet: bool) {
 
         dump_undefined_struct(&undefined_struct, smbios_data.version, quiet);
     }
+    println!();
 }
 
 pub fn dump_undefined_struct(

--- a/src/default_out.rs
+++ b/src/default_out.rs
@@ -1141,8 +1141,14 @@ pub fn dump_undefined_struct(
                     number_of_installable_languages
                 );
             }
+            let mut langs_installed = 0;
             for installable_language in data.installable_langauges() {
+                langs_installed += 1;
                 println!("\t\t{}", installable_language);
+            }
+            // TODO: done to preserve behavior of dmidecode
+            for _ in langs_installed..data.number_of_installable_languages().unwrap_or(u8::MAX) {
+                println!("\t\t{}", "<BAD INDEX>");
             }
             if let Some(current_language) = data.current_language() {
                 println!("\tCurrently Installed Language: {}", current_language);

--- a/src/default_out.rs
+++ b/src/default_out.rs
@@ -307,7 +307,7 @@ pub fn dump_undefined_struct(
                         if let Some(version) = bios_version {
                             if version < two_six_version {
                                 let p = val.raw;
-                                println!("{:02X}{:02X}{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}", 
+                                println!("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", 
                                     p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
                             } else {
                                 println!("{}", val);

--- a/src/dmifn.rs
+++ b/src/dmifn.rs
@@ -1532,13 +1532,13 @@ pub fn dmi_starting_ending_addresses(
         }
     };
 
-    let starting_address = match (starting, extended_starting) {
+    let (starting_address, using_ext_address) = match (starting, extended_starting) {
         (Some(address), Some(extended_address)) => match address == 0xFFFFFFFF {
-            true => Some(extended_address),
-            false => Some(address_32_kb_to_64_bytes(address)),
+            true => (Some(extended_address), true),
+            false => (Some(address_32_kb_to_64_bytes(address)), false),
         },
-        (Some(address), None) => Some(address_32_kb_to_64_bytes(address)),
-        _ => None,
+        (Some(address), None) => (Some(address_32_kb_to_64_bytes(address)), false),
+        _ => return,
     };
 
     let ending_address = match (ending, extended_ending) {
@@ -1547,16 +1547,28 @@ pub fn dmi_starting_ending_addresses(
             false => Some(address_32_kb_to_64_bytes(address)),
         },
         (Some(address), None) => Some(address_32_kb_to_64_bytes(address)),
-        _ => None,
+        _ => return,
     };
 
-    match (starting_address, ending_address) {
-        (Some(start), Some(end)) => {
-            println!("\tStarting Address: {:#018X}", start);
-            println!("\tEnding Address: {:#018X}", end);
-            dmi_mapped_address_extended_size(start, end);
+    // Dmidecode has different padding on addresses for extended addresses vs standard
+    if using_ext_address {
+        match (starting_address, ending_address) {
+            (Some(start), Some(end)) => {
+                println!("\tStarting Address: {:#018X}", start);
+                println!("\tEnding Address: {:#018X}", end);
+                dmi_mapped_address_extended_size(start, end);
+            }
+            _ => (),
         }
-        _ => (),
+    } else {
+        match (starting_address, ending_address) {
+            (Some(start), Some(end)) => {
+                println!("\tStarting Address: {:#013X}", start);
+                println!("\tEnding Address: {:#013X}", end);
+                dmi_mapped_address_extended_size(start, end);
+            }
+            _ => (),
+        }
     }
 }
 pub fn dmi_mapped_address_row_position(position: u8) {

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -226,6 +226,7 @@ impl BiosType {
             }
             dump_undefined_struct(&undefined_struct, data.version, quiet);
         }
+        println!();
     }
 }
 

--- a/src/dmiopt.rs
+++ b/src/dmiopt.rs
@@ -210,7 +210,7 @@ impl BiosType {
     // We could make this return something, or, could create a type as a collection containing Vec<BiosType> and
     // then implement methods for that type to perform more advanced I/O via state.
     // More than likely the style of output will be desirable to change (verbose, debug, JSON, etc).
-    pub fn parse_and_display(types: Vec<BiosType>, data: &SMBiosData, quiet: bool) {
+    pub fn parse_and_display(types: &[BiosType], data: &SMBiosData, quiet: bool) {
         let unique_types: HashSet<u8> = types
             .iter()
             .flat_map(|bios_type| bios_type.into_iter())

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,20 +45,10 @@ use structopt::StructOpt;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt: Opt = Opt::from_args();
 
-    if opt.has_no_args() {
-        print_dmidecode_version();
-        let smbios_data = platform::table_load(&opt)?;
-        println!("{}", smbios_data.1);
-        //println!("{:#X?}", smbios_data.0);
-        default_dump(&smbios_data.0, opt.quiet);
-        return Ok(());
-    }
-
     // Select an input source, file or device.
-    let smbios_data = if let Some(input) = opt.input {
+    let smbios_data = if let Some(path) = opt.input.as_ref() {
         let mut output = String::new();
 
-        let path = input.as_path();
         writeln!(
             &mut output,
             "Getting SMBIOS data from {}.",
@@ -75,11 +65,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Mutually exclusive output options (only one tuple element is Some()).
     match (
-        opt.keyword,
-        opt.output,
-        opt.bios_types,
-        opt.handle,
-        opt.oem_string,
+        opt.keyword.as_ref(),
+        opt.output.as_ref(),
+        opt.bios_types.as_ref(),
+        opt.handle.as_ref(),
+        opt.oem_string.as_ref(),
         opt.undefined_dump,
         opt.list,
         opt.json_pretty,
@@ -233,8 +223,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         _ => {
             print_dmidecode_version();
-            println!("{}", smbios_data.1);
-            println!("{:#X?}", smbios_data.0)
+            let smbios_data = platform::table_load(&opt)?;
+            print!("{}", smbios_data.1);
+            default_dump(&smbios_data.0, opt.quiet);
         }
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -62,14 +62,7 @@ fn table_load_from_sysfs() -> Result<(SMBiosData, String), Error> {
 
             writeln!(
                 &mut output,
-                "Occupying {} bytes maximum.",
-                entry_point.structure_table_maximum_size()
-            )
-            .unwrap();
-
-            writeln!(
-                &mut output,
-                "Table at: {:#010X}.",
+                "Table at {:#010X}.",
                 entry_point.structure_table_address()
             )
             .unwrap();
@@ -101,7 +94,7 @@ fn table_load_from_sysfs() -> Result<(SMBiosData, String), Error> {
 
                     writeln!(
                         &mut output,
-                        "Table at: {:#010X}.",
+                        "Table at {:#010X}.",
                         entry_point.structure_table_address()
                     )
                     .unwrap();
@@ -197,7 +190,7 @@ fn table_load_from_dev_mem(path: &Path) -> Result<(SMBiosData, String), Error> {
         }
     }
 
-    writeln!(&mut output, "Table at: {:#010X}.", structure_table_address).unwrap();
+    writeln!(&mut output, "Table at {:#010X}.", structure_table_address).unwrap();
 
     if structure_table_address + structure_table_length as u64 > RANGE_END {
         return Err(Error::new(


### PR DESCRIPTION
Now, the no-args output matches with my dmi info at least. *using latest changes on smbios-lib

```
diff dmidecode-rs/dmidecode.txt dmidecode/dmidecode.txt 
1c1
< # dmidecode-rs 0.2.1
---
> # dmidecode 3.3
```