### PR TITLE
Fix readme after gh action changes

### DIFF
--- a/.github/workflows/dmidecode_ci.yml
+++ b/.github/workflows/dmidecode_ci.yml
@@ -26,4 +26,4 @@ jobs:
       run: cargo test --verbose
     - if: matrix.os == 'macos-latest'
       name: Run MacOS tests
-      run: cargo test --verbose --skip test_oem_string_valid
+      run: cargo test --verbose -- --skip test_oem_string_valid

--- a/.github/workflows/dmidecode_ci.yml
+++ b/.github/workflows/dmidecode_ci.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 

--- a/.github/workflows/dmidecode_ci.yml
+++ b/.github/workflows/dmidecode_ci.yml
@@ -21,5 +21,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - if: matrix.os != 'macos-latest'
+      name: Run Linux and Windows tests
       run: cargo test --verbose
+    - if: matrix.os == 'macos-latest'
+      name: Run MacOS tests
+      run: cargo test --verbose --skip test_oem_string_valid

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # dmidecode-rs
 
-![Linux](https://github.com/jrgerber/dmidecode-rs/actions/workflows/linux.yml/badge.svg)
-![Windows](https://github.com/jrgerber/dmidecode-rs/actions/workflows/windows.yml/badge.svg)
-![MacOS](https://github.com/jrgerber/dmidecode-rs/actions/workflows/macos.yml/badge.svg)
+![dmidecode-rs_ci](https://github.com/jrgerber/dmidecode-rs/actions/workflows/dmidecode_ci.yml/badge.svg)
 ![LOC](https://tokei.rs/b1/github/jrgerber/dmidecode-rs?category=code)
 
 dmidecode command written in Rust, is a tool to report SMBIOS table content in human readable format.


### PR DESCRIPTION
- Fix badge on README.md
- Skip `test_oem_string_valid` on macos-latest for now.